### PR TITLE
Fix git wrapper for macOS (BSD sed and old bash)

### DIFF
--- a/bin/patdiff-git-wrapper
+++ b/bin/patdiff-git-wrapper
@@ -24,9 +24,9 @@ else
     info=""
 fi
 
-m=$(echo -ne '\e[1m')
+m=$(printf '\e[1m')
 
-echo -e "${m}patdiff -git a/$path b/$new_path"
+echo "${m}patdiff -git a/$path b/$new_path"
 
 if [[ $old_hex = . ]]; then
     cat <<EOF
@@ -34,18 +34,18 @@ ${m}new file mode $new_mode
 EOF
     path_a=/dev/null
     path_b="b/$new_path"
-    index="index 0000000..${new_hex:0:7}\n"
+    index="index 0000000..${new_hex:0:7}"
 elif [[ $new_hex = . ]]; then
     cat <<EOF
 ${m}deleted file mode $old_mode
 EOF
     path_a="a/$path"
     path_b="/dev/null"
-    index="index ${old_hex:0:7}..0000000\n"
+    index="index ${old_hex:0:7}..0000000"
 elif [[ $old_mode = $new_mode ]]; then
     path_a="a/$path"
     path_b="b/$new_path"
-    index="index ${old_hex:0:7}..${new_hex:0:7} $new_mode\n"
+    index="index ${old_hex:0:7}..${new_hex:0:7} $new_mode"
 else
     cat <<EOF
 ${m}old mode $old_mode
@@ -53,13 +53,13 @@ ${m}new mode $new_mode
 EOF
     path_a="a/$path"
     path_b="b/$new_path"
-    index="index ${old_hex:0:7}..${new_hex:0:7}\n"
+    index="index ${old_hex:0:7}..${new_hex:0:7}"
 fi
 
 # In case of moves, the "index ..." line is part of $info
 if [[ -n "$info" ]]; then
     index=""
-    echo -ne "$info" | sed "s/^/$m/"
+    printf "%s" "$info" | sed "s/^/$m/"
 fi
 
 if [[ $(file -b "$old_file") = data && $(file -b "$new_file") = data ]]; then
@@ -69,7 +69,7 @@ else
     # - not displaying the index line if the output of patdiff is empty
     # - change the style of the "--- ..." and "+++ ..." lines
     patdiff -alt-old " $path_a" -alt-new " $path_b" "$old_file" "$new_file" | \
-        sed "1,2 s/^/$m/" | sed "1 s/^/$m$index/"
+        sed "1,2 s/^/$m/" | sed "1 s/^/$m$index"$'\\\n'"/"
     # git expect non-zero only in case of error. Patdiff, just like
     # diff, returns 1 if the files are different
     ret=${PIPESTATUS[0]}


### PR DESCRIPTION
On macOS (10.13.4), the git wrapper produces output like the following:

```
\e[1mpatdiff -git a/...
\e[1mnew file mode 100644
e[1mindex 0000000..cf60d68ne[1m------  /dev/null
```

This is due to differences in bash version (macOS's /bin/bash is rather old and doesn't support `echo -e`) as well as sed version (macOS's is BSD sed which has weird behavior with [newlines in replacement strings](https://stackoverflow.com/questions/24275070/sed-not-giving-me-correct-substitute-operation-for-newline-with-mac-difference?noredirect=1&lq=1)).

I've tested this change on a Linux machine and it seems to not break anything, but let me know if there are any problems.