### PR TITLE
patdiff-git-wrapper: use relative path to patdiff.

### DIFF
--- a/bin/patdiff-git-wrapper
+++ b/bin/patdiff-git-wrapper
@@ -68,7 +68,7 @@ else
     # process the output of patdiff to:
     # - not displaying the index line if the output of patdiff is empty
     # - change the style of the "--- ..." and "+++ ..." lines
-    patdiff -alt-old " $path_a" -alt-new " $path_b" "$old_file" "$new_file" | \
+    "${BASH_SOURCE%/*}/patdiff" -alt-old " $path_a" -alt-new " $path_b" "$old_file" "$new_file" | \
         sed "1,2 s/^/$m/" | sed "1 s/^/$m$index"$'\\\n'"/"
     # git expect non-zero only in case of error. Patdiff, just like
     # diff, returns 1 if the files are different


### PR DESCRIPTION
For users who install patdiff with opam, this change avoids the issue of patdiff-git-wrapper breaking when the active opam switch is not the one with which patdiff was installed with.