### PR TITLE
Fix patdiff-git-wrapper instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ write a sample config with the `-make-config` flag.
 A simple [wrapper][patdiff-git-wrapper] is provided for using patdiff
 as git's "external diff" tool.  You can enable it with:
 
-    export GIT_EXTERNAL_DIFF=$(where patdiff-git-wrapper.sh)
+    export GIT_EXTERNAL_DIFF=$(command -v patdiff-git-wrapper)
 
 or
 
-    git config --global diff.external $(where patdiff-git-wrapper.sh)
+    git config --global diff.external $(command -v patdiff-git-wrapper)
 
 [patdiff-git-wrapper]: https://github.com/janestreet/patdiff/blob/master/bin/patdiff-git-wrapper
 


### PR DESCRIPTION
`where` is a tcsh/zsh-ism that doesn't appear to be available in other
common shells like bash.  Replace it with `command -v`, which is
specified by POSIX and available widely.

Also, update the path of the installed patdiff-git-wrapper script,
which no longer has a `.sh` extension.