### PR TITLE
patdiff-git-wrapper: Use /usr/bin/env bash instead of /bin/bash

### DIFF
--- a/bin/patdiff-git-wrapper
+++ b/bin/patdiff-git-wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Simple wrapper to use patdiff with git, as external diff tool
 # You may enable it with


### PR DESCRIPTION
/bin/bash doesn't exist on some systems, such as on NixOS.  Instead,
use whatever bash is in PATH.