### PR TITLE
Eliminate dependency on Pcre

### DIFF
--- a/bin/compare.ml
+++ b/bin/compare.ml
@@ -4,6 +4,7 @@ module Compare_core = Patdiff.Compare_core
 module Configuration = Patdiff.Configuration
 module Format = Patdiff.Format
 module Output = Patdiff.Output
+module Pcre = Re.Pcre
 
 let summary =
   {|Compare two files (or process a diff read in on stdin) using the
@@ -153,6 +154,7 @@ let compare_main (args : Args.compare_flags) =
      | None -> failwithf "File not found in %s: %s" dir file ())
   | true, true ->
     (* Both are directories *)
+    let memo_rex = Memo.general (fun pat -> Pcre.regexp pat) in
     let file_filter =
       match args with
       | { include_ = []; exclude = []; _ } -> None
@@ -161,9 +163,9 @@ let compare_main (args : Args.compare_flags) =
           (fun (s, stat) ->
              match stat.Unix.st_kind with
              | Unix.S_REG ->
-               List.for_all exclude ~f:(fun pat -> not (Pcre.pmatch s ~pat))
+               List.for_all exclude ~f:(fun pat -> not (Pcre.pmatch s ~rex:(memo_rex pat)))
                && (List.is_empty include_
-                   || List.exists include_ ~f:(fun pat -> Pcre.pmatch s ~pat))
+                   || List.exists include_ ~f:(fun pat -> Pcre.pmatch s ~rex:(memo_rex pat)))
              | _ -> true)
     in
     Compare_core.diff_dirs ~prev_dir:prev_file ~next_dir:next_file config ~file_filter

--- a/bin/dune
+++ b/bin/dune
@@ -1,9 +1,23 @@
-(executables (names main)
- (libraries core_unix.command_unix core core_unix.filename_unix patdiff pcre
+(executables
+ (names main)
+ (libraries
+  core_unix.command_unix
+  core
+  core_unix.filename_unix
+  patdiff
   core_unix.sys_unix)
- (preprocess (pps ppx_jane)))
+ (preprocess
+  (pps ppx_jane)))
 
-(install (section bin) (files (main.exe as patdiff) patdiff-git-wrapper))
+(install
+ (section bin)
+ (files
+  (main.exe as patdiff)
+  patdiff-git-wrapper))
 
-(alias (name DEFAULT) (deps (glob_files patdiff-git-wrapper))
- (action (bash "%{bin:shellcheck} -x patdiff-git-wrapper")))
+(alias
+ (name DEFAULT)
+ (deps
+  (glob_files patdiff-git-wrapper))
+ (action
+  (bash "%{bin:shellcheck} -x patdiff-git-wrapper")))

--- a/patdiff.opam
+++ b/patdiff.opam
@@ -18,7 +18,6 @@ depends: [
   "patience_diff"
   "ppx_jane"
   "dune"                     {>= "2.0.0"}
-  "pcre"
   "re"                       {>= "1.8.0"}
 ]
 synopsis: "File Diff using the Patience Diff algorithm"


### PR DESCRIPTION
`patdiff` already depends on `re` but continues to use `pcre` in one place: when doing whole-directory comparisons and deciding whether to `-include` or `-exclude` files by pattern.

I suspect this was preserved to not break patterns that specifically depend on `Pcre` semantics, but I noticed the `Re` library specifically contains a `Pcre` sub-module, so, this seems like a natural fit.

Thanks for your consideration.

Oh, what's the gain here? Besides the more general spiritual victory of using the pure-OCaml `re` library, there's the practical benefit of no-longer needing to install `libpcre3-dev` on systems that want to build `patdiff`.
