### PR TITLE
Report package version from Dune build info

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -2,7 +2,7 @@
  (modes byte exe)
  (names main)
  (libraries core_unix.command_unix core core_unix core_unix.filename_unix
-   patdiff re core_unix.sys_unix)
+   dune-build-info patdiff re core_unix.sys_unix)
  (preprocess
   (pps ppx_jane)))
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,7 +1,13 @@
 open Core
 
+let version =
+  match Build_info.V1.version () with
+  | None -> "n/a"
+  | Some version -> Build_info.V1.Version.to_string version
+;;
+
 let () =
-  let result = Result.try_with (fun () -> Command_unix.run Compare.command) in
+  let result = Result.try_with (fun () -> Command_unix.run ~version Compare.command) in
   match result with
   | Ok () -> ()
   | Error exn ->

--- a/patdiff.opam
+++ b/patdiff.opam
@@ -22,6 +22,7 @@ depends: [
   "ppx_jane"
   "angstrom"                 {>= "0.15.0"}
   "dune"                     {>= "3.17.0"}
+  "dune-build-info"
   "re"                       {>= "1.8.0"}
   "uucp"
 ]


### PR DESCRIPTION
## Summary
- source `patdiff -version` from Dune build info instead of the internal Jane Street fallback
- report `n/a` for development binaries before artifact substitution
- declare the `dune-build-info` executable and opam dependency

## Why
External builds currently inherit `core_unix.command_unix`'s compatibility fallback and print `NO_VERSION_UTIL`. Dune build info records the package version during artifact substitution, so installed release binaries can report their actual version.

## Validation
- `git diff --check`
- verified the `Build_info.V1.version` API and `n/a` development fallback against Dune's implementation

Fixes #27